### PR TITLE
#12: Corrige alinhamento dos elementos textuais

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -508,6 +508,14 @@
                 }
             }
         }
+
+        p, h1, h2, h3, h4, h5, h6 {
+            width: 100%;
+        }
+
+        code {
+            display: inline-block;
+        }
     }
 
 /* Icon */


### PR DESCRIPTION
Antes da alteração os elementos `h` e `p` não estavam sendo exibidas corretamente. Na página da [issue](https://github.com/diversidade/diversidade.github.io/issues/12) tem algumas imagens mostrando antes e depois.